### PR TITLE
Hotfix: Added permissions to store docker image in the organization store

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   build:
+    permissions: write-all
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Unlike personal package storage, an organization package storage requires explicit definition of write-all permissions in GitHub Actions to publish packages.
This commit add this permission and fixes failed build on the main branch.