### PR TITLE
Secure Connection for Deployment

### DIFF
--- a/routes/appointment.go
+++ b/routes/appointment.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gin-gonic/gin"
 	sf "github.com/sa-/slicefunk"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 // AppointmentIDHolder implements AppointmentIDHolder schema.
@@ -282,7 +281,7 @@ func RegisterAppointmentRoutes(router *gin.Engine) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	conn, err := grpc.NewClient(appointmentService.GetAddr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(appointmentService.GetAddr(), grpc.WithTransportCredentials(GetTransportCredentials()))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/routes/patient.go
+++ b/routes/patient.go
@@ -13,7 +13,6 @@ import (
 	patients "github.com/TekClinic/Patients-MicroService/patients_protobuf"
 	"github.com/gin-gonic/gin"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 const resourceName = "patient"
@@ -164,7 +163,7 @@ func RegisterPatientRoutes(router *gin.Engine) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	conn, err := grpc.NewClient(patientsService.GetAddr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(patientsService.GetAddr(), grpc.WithTransportCredentials(GetTransportCredentials()))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/routes/utils.go
+++ b/routes/utils.go
@@ -1,10 +1,16 @@
 package routes
 
 import (
+	"crypto/tls"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	ms "github.com/TekClinic/MicroService-Lib"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/gin-contrib/location"
 
@@ -110,4 +116,18 @@ func HandleGRPCError(err error, ctx *gin.Context) {
 			Message: fmt.Sprintf("unknown error occurred: %s", err.Error()),
 		})
 	}
+}
+
+// GetTransportCredentials returns gRPC transport credentials based on the SECURE_CONN environment variable.
+func GetTransportCredentials() credentials.TransportCredentials {
+	secure, err := strconv.ParseBool(ms.GetOptionalEnv("SECURE_CONN", "false"))
+	if err != nil {
+		log.Println("SECURE environment variable is not a boolean, defaulting to false")
+		secure = false
+	}
+
+	if secure {
+		return credentials.NewTLS(&tls.Config{InsecureSkipVerify: false, MinVersion: tls.VersionTLS12})
+	}
+	return insecure.NewCredentials()
 }


### PR DESCRIPTION
In some deploy environment it may be crucial to handle gRPC connections over TLS, thus this fix adds the given option.